### PR TITLE
Only set Secitem Labels if they are provided

### DIFF
--- a/Sources/AwsIotDeviceSdkSwift/mqtt5ClientBuilder.swift
+++ b/Sources/AwsIotDeviceSdkSwift/mqtt5ClientBuilder.swift
@@ -767,8 +767,8 @@ public class Mqtt5ClientBuilder {
                 }
 
                 // Apply labels if available
-                if let certLabel = _certLabel, let keyLabel = _keyLabel {
-                    try tlsOptions.setSecitemLabels(certLabel: certLabel, keyLabel: keyLabel)
+                if _certLabel != nil || _keyLabel != nil {
+                    try tlsOptions.setSecitemLabels(certLabel: _certLabel, keyLabel: _keyLabel)
                 }
 
                 _tlsCtx = try TLSContext(options: tlsOptions, mode: .client)


### PR DESCRIPTION
We were calling `setSecitemLabels()` even if they weren't set.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
