### PR TITLE
Make Mqtt5 client callbacks synchronous

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.49.1"))
+            url: "https://github.com/awslabs/aws-crt-swift.git", branch: "mqtt-callbacks")
+            // .upToNextMajor(from: "0.49.1"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/awslabs/aws-crt-swift.git", branch: "mqtt-callbacks")
-            // .upToNextMajor(from: "0.49.1"))
+            url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.50.0"))
     ],
     targets: [
         .target(

--- a/Samples/Mqtt5ConnectionSamples/CertAndKeyFileConnect/Sources/main.swift
+++ b/Samples/Mqtt5ConnectionSamples/CertAndKeyFileConnect/Sources/main.swift
@@ -65,24 +65,23 @@ struct CertAndKeyFileConnectSample: ParsableCommand {
              **************************************/
             // Callbacks to be assigned to builder
             // The full list of callbacks and their uses can be found in the MQTT5 User Guide
-            func onLifecycleEventStopped(_: LifecycleStoppedData) async {
+            func onLifecycleEventStopped(_: LifecycleStoppedData) {
                 print("Mqtt5Client: onLifecycleEventStopped callback invoked.")
                 stoppedSemaphore.signal()
             }
-            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) async {
+            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) {
                 print("Mqtt5Client: onLifecycleEventAttemptingConnect callback invoked.")
             }
-            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) async {
+            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) {
                 print("Mqtt5Client: onLifecycleEventConnectionSuccess callback invoked.")
                 connectionSemaphore.signal()
             }
-            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData)
-                async {
+            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData) {
                 print(
                     "Mqtt5Client: onLifecycleEventConnectionFailure callback invoked with Error Code \(failureData.crtError.code): \(failureData.crtError.message)"
                 )
             }
-            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) async {
+            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) {
                 print(
                     "Mqtt5Client: onLifecycleEventDisconnection callback invoked with Error Code \(disconnectionData.crtError.code): \(disconnectionData.crtError.message)"
                 )

--- a/Samples/Mqtt5ConnectionSamples/CognitoWebsocketConnect/Sources/main.swift
+++ b/Samples/Mqtt5ConnectionSamples/CognitoWebsocketConnect/Sources/main.swift
@@ -88,24 +88,23 @@ struct CognitoWebsocketSample: ParsableCommand {
              **************************************/
             // Callbacks to be assigned to builder
             // The full list of callbacks and their uses can be found in the MQTT5 User Guide
-            func onLifecycleEventStopped(_: LifecycleStoppedData) async {
+            func onLifecycleEventStopped(_: LifecycleStoppedData) {
                 print("Mqtt5Client: onLifecycleEventStopped callback invoked.")
                 stoppedSemaphore.signal()
             }
-            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) async {
+            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) {
                 print("Mqtt5Client: onLifecycleEventAttemptingConnect callback invoked.")
             }
-            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) async {
+            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) {
                 print("Mqtt5Client: onLifecycleEventConnectionSuccess callback invoked.")
                 connectionSemaphore.signal()
             }
-            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData)
-                async {
+            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData) {
                 print(
                     "Mqtt5Client: onLifecycleEventConnectionFailure callback invoked with Error Code \(failureData.crtError.code): \(failureData.crtError.message)"
                 )
             }
-            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) async {
+            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) {
                 print(
                     "Mqtt5Client: onLifecycleEventDisconnection callback invoked with Error Code \(disconnectionData.crtError.code): \(disconnectionData.crtError.message)"
                 )

--- a/Samples/Mqtt5ConnectionSamples/CustomAuthConnect/Sources/main.swift
+++ b/Samples/Mqtt5ConnectionSamples/CustomAuthConnect/Sources/main.swift
@@ -104,24 +104,23 @@ struct SignedCustomAuthSample: ParsableCommand {
              **************************************/
             // Callbacks to be assigned to builder
             // The full list of callbacks and their uses can be found in the MQTT5 User Guide
-            func onLifecycleEventStopped(_: LifecycleStoppedData) async {
+            func onLifecycleEventStopped(_: LifecycleStoppedData) {
                 print("Mqtt5Client: onLifecycleEventStopped callback invoked.")
                 stoppedSemaphore.signal()
             }
-            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) async {
+            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) {
                 print("Mqtt5Client: onLifecycleEventAttemptingConnect callback invoked.")
             }
-            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) async {
+            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) {
                 print("Mqtt5Client: onLifecycleEventConnectionSuccess callback invoked.")
                 connectionSemaphore.signal()
             }
-            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData)
-                async {
+            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData) {
                 print(
                     "Mqtt5Client: onLifecycleEventConnectionFailure callback invoked with Error Code \(failureData.crtError.code): \(failureData.crtError.message)"
                 )
             }
-            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) async {
+            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) {
                 print(
                     "Mqtt5Client: onLifecycleEventDisconnection callback invoked with Error Code \(disconnectionData.crtError.code): \(disconnectionData.crtError.message)"
                 )

--- a/Samples/Mqtt5ConnectionSamples/Pkcs12Connect/Sources/main.swift
+++ b/Samples/Mqtt5ConnectionSamples/Pkcs12Connect/Sources/main.swift
@@ -65,24 +65,23 @@ struct PKCS12Sample: ParsableCommand {
              **************************************/
             // Callbacks to be assigned to builder
             // The full list of callbacks and their uses can be found in the MQTT5 User Guide
-            func onLifecycleEventStopped(_: LifecycleStoppedData) async {
+            func onLifecycleEventStopped(_: LifecycleStoppedData) {
                 print("Mqtt5Client: onLifecycleEventStopped callback invoked.")
                 stoppedSemaphore.signal()
             }
-            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) async {
+            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) {
                 print("Mqtt5Client: onLifecycleEventAttemptingConnect callback invoked.")
             }
-            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) async {
+            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) {
                 print("Mqtt5Client: onLifecycleEventConnectionSuccess callback invoked.")
                 connectionSemaphore.signal()
             }
-            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData)
-                async {
+            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData) {
                 print(
                     "Mqtt5Client: onLifecycleEventConnectionFailure callback invoked with Error Code \(failureData.crtError.code): \(failureData.crtError.message)"
                 )
             }
-            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) async {
+            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) {
                 print(
                     "Mqtt5Client: onLifecycleEventDisconnection callback invoked with Error Code \(disconnectionData.crtError.code): \(disconnectionData.crtError.message)"
                 )

--- a/Samples/Mqtt5ConnectionSamples/Sigv4WebsocketConnect/Sources/main.swift
+++ b/Samples/Mqtt5ConnectionSamples/Sigv4WebsocketConnect/Sources/main.swift
@@ -99,24 +99,23 @@ struct Sigv4WebsocketSample: ParsableCommand {
              **************************************/
             // Callbacks to be assigned to builder
             // The full list of callbacks and their uses can be found in the MQTT5 User Guide
-            func onLifecycleEventStopped(_: LifecycleStoppedData) async {
+            func onLifecycleEventStopped(_: LifecycleStoppedData) {
                 print("Mqtt5Client: onLifecycleEventStopped callback invoked.")
                 stoppedSemaphore.signal()
             }
-            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) async {
+            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) {
                 print("Mqtt5Client: onLifecycleEventAttemptingConnect callback invoked.")
             }
-            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) async {
+            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) {
                 print("Mqtt5Client: onLifecycleEventConnectionSuccess callback invoked.")
                 connectionSemaphore.signal()
             }
-            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData)
-                async {
+            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData) {
                 print(
                     "Mqtt5Client: onLifecycleEventConnectionFailure callback invoked with Error Code \(failureData.crtError.code): \(failureData.crtError.message)"
                 )
             }
-            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) async {
+            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) {
                 print(
                     "Mqtt5Client: onLifecycleEventDisconnection callback invoked with Error Code \(disconnectionData.crtError.code): \(disconnectionData.crtError.message)"
                 )

--- a/Samples/Mqtt5Sample/Sources/main.swift
+++ b/Samples/Mqtt5Sample/Sources/main.swift
@@ -54,29 +54,28 @@ struct Mqtt5Sample: AsyncParsableCommand {
 
             // Callbacks to be assigned to the builder
             // The full list of callbacks and their uses can be found in the MQTT5 User Guide
-            func onLifecycleEventStopped(_: LifecycleStoppedData) async {
+            func onLifecycleEventStopped(_: LifecycleStoppedData) {
                 print("Mqtt5Client: onLifecycleEventStopped callback invoked.")
             }
-            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) async {
+            func onLifecycleEventAttemptingConnect(_: LifecycleAttemptingConnectData) {
                 print("Mqtt5Client: onLifecycleEventAttemptingConnect callback invoked.")
             }
-            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) async {
+            func onLifecycleEventConnectionSuccess(_: LifecycleConnectionSuccessData) {
                 print("Mqtt5Client: onLifecycleEventConnectionSuccess callback invoked.")
             }
-            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData)
-                async {
+            func onLifecycleEventConnectionFailure(failureData: LifecycleConnectionFailureData) {
                 print(
                     "Mqtt5Client: onLifecycleEventConnectionFailure callback invoked with Error Code \(failureData.crtError.code): \(failureData.crtError.message)"
                 )
             }
-            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) async {
+            func onLifecycleEventDisconnection(disconnectionData: LifecycleDisconnectData) {
                 print(
                     "Mqtt5Client: onLifecycleEventDisconnection callback invoked with Error Code \(disconnectionData.crtError.code): \(disconnectionData.crtError.message)"
                 )
             }
 
             // The onPublishReceived callback handles all publish packets the Mqtt5 Client receives.
-            func onPublishReceived(publishData: PublishReceivedData) async {
+            func onPublishReceived(publishData: PublishReceivedData) {
                 let packet: PublishPacket = publishData.publishPacket
                 let payload = packet.payloadAsString() ?? "[no payload]"
                 print(

--- a/Samples/iOS/iOSPubSubSample/MqttClient/ContentView.swift
+++ b/Samples/iOS/iOSPubSubSample/MqttClient/ContentView.swift
@@ -87,13 +87,15 @@ public var onLifecycleEventAttemptingConnect: OnLifecycleEventAttemptingConnect 
 public var onLifecycleEventConnectionSuccess: OnLifecycleEventConnectionSuccess = { _ in
     mqttTestContext.printView("Lifecycle Event Connection Success")
     // 3. If connection succeed, subscribe to topic
-    do {
-        let suback = try await client!.subscribe(
-            subscribePacket: SubscribePacket(
-                subscription: Subscription(topicFilter: TEST_TOPIC, qos: QoS.atLeastOnce)))
-        print("SubackPacket received with result \(suback.reasonCodes[0])")
-    } catch {
-        print("Client failed to subscribe. ")
+    Task {
+        do {
+            let suback = try await client!.subscribe(
+                subscribePacket: SubscribePacket(
+                    subscription: Subscription(topicFilter: TEST_TOPIC, qos: QoS.atLeastOnce)))
+            print("SubackPacket received with result \(suback.reasonCodes[0])")
+        } catch {
+            print("Client failed to subscribe. ")
+        }
     }
 }
 public var onLifecycleEventConnectionFailure: OnLifecycleEventConnectionFailure = { failureData in

--- a/Sources/AwsIotDeviceSdkSwift/mqtt5ClientBuilder.swift
+++ b/Sources/AwsIotDeviceSdkSwift/mqtt5ClientBuilder.swift
@@ -116,14 +116,15 @@ public class Mqtt5ClientBuilder {
             region: region,
             credentialsProvider: credentialsProvider,
             omitSessionToken: true)
-
         _onWebsocketTransform = { httpRequest, completCallback in
-            do {
-                let returnedHttpRequest = try await Signer.signRequest(
-                    request: httpRequest, config: signingConfig)
-                completCallback(returnedHttpRequest, 0)
-            } catch {
-                completCallback(httpRequest, -1)
+            Task {
+                do {
+                    let returnedHttpRequest = try await Signer.signRequest(
+                        request: httpRequest, config: signingConfig)
+                    completCallback(returnedHttpRequest, 0)
+                } catch {
+                    completCallback(httpRequest, -1)
+                }
             }
         }
     }


### PR DESCRIPTION
The MQTT5 client callbacks are now synchronous. Instead of being scheduled in their own task block for execution, they will now be handled directly on the CRT I/O thread (eventloop).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
