### PR TITLE
Update CRT to 0.54.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,28 +110,28 @@ jobs:
             - macos-15
           target:
             [{ os: ios, destination: 'iOS Simulator,OS=17.2,name=iPhone 15'},
-            { os: ios, destination: 'iOS Simulator,OS=18.1,name=iPhone 16'},
+            { os: ios, destination: 'iOS Simulator,OS=18.4,name=iPhone 16'},
             { os: tvos, destination: 'tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'},
-            { os: tvos, destination: 'tvOS Simulator,OS=18.1,name=Apple TV 4K (3rd generation) (at 1080p)'}]
+            { os: tvos, destination: 'tvOS Simulator,OS=18.4,name=Apple TV 4K (3rd generation) (at 1080p)'}]
           xcode:
             - Xcode_15.2
-            - Xcode_16.1
+            - Xcode_16.3
           exclude:
             # Don't run old macOS with new Xcode
             - runner: macos-14
-              xcode: Xcode_16.1
+              xcode: Xcode_16.3
             # Don't run new macOS with old Xcode
             - runner: macos-15
               xcode: Xcode_15.2
             # Don't run old simulators with new Xcode
             - target: { os: tvos, destination: 'tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)' }
-              xcode: Xcode_16.1
+              xcode: Xcode_16.3
             - target: { os: ios, destination: 'iOS Simulator,OS=17.2,name=iPhone 15' }
-              xcode: Xcode_16.1
+              xcode: Xcode_16.3
             # Don't run new simulators with old Xcode
-            - target: { os: tvos, destination: 'tvOS Simulator,OS=18.1,name=Apple TV 4K (3rd generation) (at 1080p)' }
+            - target: { os: tvos, destination: 'tvOS Simulator,OS=18.4,name=Apple TV 4K (3rd generation) (at 1080p)' }
               xcode: Xcode_15.2
-            - target: { os: ios, destination: 'iOS Simulator,OS=18.1,name=iPhone 16' }
+            - target: { os: ios, destination: 'iOS Simulator,OS=18.4,name=iPhone 16' }
               xcode: Xcode_15.2
       permissions:
         id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
             # Don't run old macOS with new Xcode
             - runner: macos-14
               xcode: Xcode_16.3
+            # Don't run old macOS with new Xcode
+            - runner: macos-14-large
+              xcode: Xcode_16.3
             # Don't run new macOS with old Xcode
             - runner: macos-15
               xcode: Xcode_15.2

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.53.0")),
+      url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.54.0")),
     // aws-sdk-swift is only used in test targets to help with setup and cleanup of testing service clients
     // We use "aws-iot-device-sdk-swift-testing-branch" to maintain aws-crt-swift version pairity between it
     // and our SDK for testing

--- a/Package.swift
+++ b/Package.swift
@@ -36,10 +36,10 @@ let package = Package(
     //        a. fork from https://github.com/sbSteveK/smithy-swift.git
     //        b. pull in latest https://github.com/smithy-lang/smithy-swift and update aws-crt-swift version in `Package.swift`
     //        c. create a PR to sbSteveK/smithy, and submit for @sbstevek to review and merge
-    //        d. go to latest Package.swift from awslabs/aws-crt-swift, and look for `clientRuntimeVersion`. This is the version tag of smithy-swift that aws-sdk-swift is using. 
+    //        d. go to latest Package.swift from awslabs/aws-crt-swift, and look for `clientRuntimeVersion`. This is the version tag of smithy-swift that aws-sdk-swift is using.
     //        e. cut a release in sbSteveK/smithy using the same version tag as `clientRuntimeVersion`
     //    2. Update crt version for https://github.com/awslabs/aws-sdk-swift
-    //        a. branch from "aws-iot-device-sdk-swift-testing-branch" 
+    //        a. branch from "aws-iot-device-sdk-swift-testing-branch"
     //        b. pull in the latest main and update crt version as needed
     //        c. submit PR against "aws-iot-device-sdk-swift-testing-branch" for review and merge
     // Once the PRs are merged, you can update the version here for aws-crt-swift, remember to test locally to make sure the Package.swift resolves correctly.

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,20 @@ let package = Package(
       url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.54.0")),
     // aws-sdk-swift is only used in test targets to help with setup and cleanup of testing service clients
     // We use "aws-iot-device-sdk-swift-testing-branch" to maintain aws-crt-swift version pairity between it
-    // and our SDK for testing
+    // and our SDK for testing. As aws-sdk-swift depends on swift-smithy, which also uses aws-crt-swift, we
+    // keep the versions in sync using a fork https://github.com/sbSteveK/smithy-swift
+    // Steps for updating the versions:
+    //    1. Update crt version for smithy-swift
+    //        a. fork from https://github.com/sbSteveK/smithy-swift.git
+    //        b. pull in latest https://github.com/smithy-lang/smithy-swift and update aws-crt-swift version in `Package.swift`
+    //        c. create a PR to sbSteveK/smithy, and submit for @sbstevek to review and merge
+    //        d. go to latest Package.swift from awslabs/aws-crt-swift, and look for `clientRuntimeVersion`. This is the version tag of smithy-swift that aws-sdk-swift is using. 
+    //        e. cut a release in sbSteveK/smithy using the same version tag as `clientRuntimeVersion`
+    //    2. Update crt version for https://github.com/awslabs/aws-sdk-swift
+    //        a. branch from "aws-iot-device-sdk-swift-testing-branch" 
+    //        b. pull in the latest main and update crt version as needed
+    //        c. submit PR against "aws-iot-device-sdk-swift-testing-branch" for review and merge
+    // Once the PRs are merged, you can update the version here for aws-crt-swift, remember to test locally to make sure the Package.swift resolves correctly.
     .package(
       url: "https://github.com/awslabs/aws-sdk-swift.git",
       branch: "aws-iot-device-sdk-swift-testing-branch"),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. aws-crt-swift -> v0.54.0
2. Update CI to test with Xcode_16.3. Github runner image changes the Xcode support, and no longer provide simulator runtime for Xcode_16.2 and below (https://github.com/actions/runner-images/issues/12541). The "proper" way might be manually download the simulator runtime so we can guarantee we always have the specific simulator, however, in that case, we would need download 22+G resources in CI. For now, I simply update to use Xcode_16.3 so we don't need to download 22G simulator runtimes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
