### PR TITLE
aws-crt-swift v0.54.0 -> v0.55.0

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -7,6 +7,7 @@
 * [I keep getting AWS_ERROR_MQTT_UNEXPECTED_HANGUP](#i-keep-getting-aws_error_mqtt_unexpected_hangup)
 * [What certificates do I need?](#what-certificates-do-i-need)
 * [Error: unable to create symlink aws-common-runtime/config/s2n: Permission denied](#error-unable-to-create-symlink-aws-common-runtimeconfigs2n-Permission-denied)
+* [Certificate and Private Key Usage Across Different Versions of the SDK on macOS](#certificate-and-private-key-usage-across-different-versions-of-the-sdk-on-macos)
 * [To learn more about this SDK](#to-learn-more-about-this-sdk)
 
 ### Where should I start?
@@ -74,6 +75,9 @@ The AWS IoT Device SDK for Swift supports the following platforms:
 * iOS
 * tvOS
 * Linux
+
+### Certificate and Private Key Usage Across Different Versions of the SDK on macOS
+A certificate and private key pair cannot be shared on a macOS device between aws-iot-device-sdk-swift v0.5.0 and an earlier version. In the update to v0.5.0 we migrated macOS from using Apple's deprecated Security Framework to SecItem API. In doing so, certificate and private keys are imported in a non-backwards compatible manner into the Apple Keychain.
 
 ### To learn more about this SDK
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.54.0")),
+      url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.55.0")),
     // aws-sdk-swift is only used in test targets to help with setup and cleanup of testing service clients
     // We use "aws-iot-device-sdk-swift-testing-branch" to maintain aws-crt-swift version pairity between it
     // and our SDK for testing. As aws-sdk-swift depends on swift-smithy, which also uses aws-crt-swift, we

--- a/README.md
+++ b/README.md
@@ -87,15 +87,6 @@ Check out the [Samples](./Samples/README.md) directory for working code examples
 
 The samples provide ready-to-run code with detailed setup instructions for each authentication method and use case.
 
-## Mac-Only TLS Behavior
-
-Note: On Mac, after a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Mac Keychain is used, the following is logged at the "info" log level:
-
-```
-static: certificate has an existing certificate-key pair that was previously imported into the Keychain.
- Using key from Keychain instead of the one provided.
-```
-
 ## Getting Help
 
 The best way to interact with our team is through GitHub.


### PR DESCRIPTION
aws-crt-swift v0.54.0 -> v0.55.0
This includes migration of macOS from kqueue and security framework to Apple's dispatch queue, network, and secitem framework.
[Related Announcement Post](https://github.com/aws/aws-iot-device-sdk-swift/discussions/51)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
