### PR TITLE
Update aws-crt to bring TLS 1.3 error on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.56.0")),
+      url: "https://github.com/awslabs/aws-crt-swift.git", .upToNextMajor(from: "0.57.0")),
     // aws-sdk-swift is only used in test targets to help with setup and cleanup of testing service clients
     // We use "aws-iot-device-sdk-swift-testing-branch" to maintain aws-crt-swift version pairity between it
     // and our SDK for testing. As aws-sdk-swift depends on swift-smithy, which also uses aws-crt-swift, we


### PR DESCRIPTION
Update awscrt to v0.56.0

This update includes returning error on using tls13 on macOS.
See https://github.com/awslabs/aws-c-io/pull/788

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
