### PR TITLE
Update sample docs

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -5,6 +5,7 @@
 * [How do I enable logging](#how-do-i-enable-logging)
 * [I am getting OSStatus -34018 when adding a certificate](#i-am-getting-osstatus--34018-when-adding-a-certificate)
 * [I keep getting AWS_ERROR_MQTT_UNEXPECTED_HANGUP](#i-keep-getting-aws_error_mqtt_unexpected_hangup)
+* [What is Error Code 5153 (AWS_ERROR_MQTT5_USER_REQUESTED_STOP)?](#what-is-error-code-5153-aws_error_mqtt5_user_requested_stop)
 * [What certificates do I need?](#what-certificates-do-i-need)
 * [Error: unable to create symlink aws-common-runtime/config/s2n: Permission denied](#error-unable-to-create-symlink-aws-common-runtimeconfigs2n-Permission-denied)
 * [Certificate and Private Key Usage Across Different Versions of the SDK on macOS](#certificate-and-private-key-usage-across-different-versions-of-the-sdk-on-macos)
@@ -50,6 +51,18 @@ This error is most likely due to a policy issue. Try using a super permissive IA
 ```
 
 After you resolve this error, make sure to only allow the actions and resources that you need. To learn more about IAM policies for AWS IoT, see [How AWS IoT works with IAM](https://docs.aws.amazon.com/iot/latest/developerguide/security_iam_service-with-iam.html) in the *AWS IoT Core Developer Guide*.
+
+### What is Error Code 5153 (AWS_ERROR_MQTT5_USER_REQUESTED_STOP)?
+
+Error code 5153 (`AWS_ERROR_MQTT5_USER_REQUESTED_STOP`) is **not an error**. It is an informational status code indicating that the MQTT5 client connection was closed because your application called `client.stop()`.
+
+The SDK reports all connection shutdown reasons through error codes, including intentional disconnections. When you see this in your logs:
+
+```
+Mqtt5 client connection interrupted by user request.
+```
+
+It means the disconnect was initiated by your code, not by a network failure or broker rejection. This is the expected behavior when gracefully shutting down a connection.
 
 ### What certificates do I need?
 

--- a/Documentation/MQTT5_Userguide.md
+++ b/Documentation/MQTT5_Userguide.md
@@ -6,7 +6,7 @@
 * [Connecting to AWS IoT Core](#connecting-to-aws-iot-core)
 * [Creating an MQTT 5 Client](#creating-an-mqtt-5-client)
     * [Direct MQTT with X.509-based Mutual TLS](#direct-mqtt-with-x509-based-mutual-tls)
-    * [Direct MQTT with PKCS #12 Method (macOS only)](#direct-mqtt-with-pkcs-12-method-macos-only)
+    * [Direct MQTT with PKCS #12 Method](#direct-mqtt-with-pkcs-12-method)
     * [Direct MQTT with Custom Authentication](#direct-mqtt-with-custom-authentication)
     * [MQTT over WebSockets with Amazon Cognito Authentication](#mqtt-over-websockets-with-amazon-cognito-authentication)
 * [Assigning Callbacks and Optional Configurations](#assigning-callbacks-and-optional-configurations)
@@ -65,7 +65,7 @@ For X.509-based Mutual TLS (mTLS), you can create a client where the certificate
     let client = try clientBuilder.build()
 ```
 
-#### **Direct MQTT with PKCS #12 Method (macOS only)**
+#### **Direct MQTT with PKCS #12 Method**
 
 An MQTT 5 direct connection can be made using a PKCS #12 file rather than using a PEM encoded private key. To create an MQTT 5 builder configured for this connection, see the following code:
 

--- a/Documentation/MQTT5_Userguide.md
+++ b/Documentation/MQTT5_Userguide.md
@@ -6,7 +6,7 @@
 * [Connecting to AWS IoT Core](#connecting-to-aws-iot-core)
 * [Creating an MQTT 5 Client](#creating-an-mqtt-5-client)
     * [Direct MQTT with X.509-based Mutual TLS](#direct-mqtt-with-x509-based-mutual-tls)
-    * [Direct MQTT with PKCS #12 Method](#direct-mqtt-with-pkcs-12-method)
+    * [Direct MQTT with PKCS #12 Method (macOS only)](#direct-mqtt-with-pkcs-12-method-macos-only)
     * [Direct MQTT with Custom Authentication](#direct-mqtt-with-custom-authentication)
     * [MQTT over WebSockets with Amazon Cognito Authentication](#mqtt-over-websockets-with-amazon-cognito-authentication)
 * [Assigning Callbacks and Optional Configurations](#assigning-callbacks-and-optional-configurations)
@@ -65,7 +65,7 @@ For X.509-based Mutual TLS (mTLS), you can create a client where the certificate
     let client = try clientBuilder.build()
 ```
 
-#### **Direct MQTT with PKCS #12 Method**
+#### **Direct MQTT with PKCS #12 Method (macOS only)**
 
 An MQTT 5 direct connection can be made using a PKCS #12 file rather than using a PEM encoded private key. To create an MQTT 5 builder configured for this connection, see the following code:
 

--- a/Samples/Mqtt5Sample/README.md
+++ b/Samples/Mqtt5Sample/README.md
@@ -24,7 +24,7 @@ The [What is AWS IoT](https://docs.aws.amazon.com/iot/latest/developerguide/what
 ### Build the sample
 ```
 // The sample should be built from the sample's folder
-cd aws-iot-device-sdk-swift/Samples/Mqtt5PubSub
+cd aws-iot-device-sdk-swift/Samples/Mqtt5Samples
 
 // build the sample
 swift build

--- a/Samples/Mqtt5Sample/Sources/main.swift
+++ b/Samples/Mqtt5Sample/Sources/main.swift
@@ -13,16 +13,16 @@ struct Mqtt5Sample: AsyncParsableCommand {
   /**************************************
   * Arguments used by ArgumentParser
   **************************************/
-  @Argument(help: "The endpoint to connect to.")
+  @Option(help: "The endpoint to connect to.")
   var endpoint: String
 
-  @Argument(help: "The path to the certificate file.")
+  @Option(help: "The path to the certificate file.")
   var cert: String
 
-  @Argument(help: "The path to the private key file.")
+  @Option(help: "The path to the private key file.")
   var key: String
 
-  @Argument(
+  @Option(
     help: "Client id to use (optional). Please make sure the client id matches the policy.")
   var clientId: String = "test-" + UUID().uuidString
 


### PR DESCRIPTION
Fixes several documentation gaps and a sample code issue across the MQTT5 SDK.

*Description of Changes*

- Add FAQ entry explaining error code 5153 (`AWS_ERROR_MQTT5_USER_REQUESTED_STOP`) is informational, not a failure
- Fix incorrect build path in Mqtt5Sample README (`Mqtt5PubSub `→ `Mqtt5Samples`)
- Change `@Argument` to `@Option` for CLI parameters in Mqtt5Sample for consistency with other samples