### PR TITLE
Remove aws-sdk-swift dependency for jobs sandbox sample

### DIFF
--- a/Samples/ServiceClientSamples/JobsSample/Package.swift
+++ b/Samples/ServiceClientSamples/JobsSample/Package.swift
@@ -17,9 +17,6 @@ let package = Package(
     .package(path: "../../../"),
     // This package gives us the capability to do a argument parsing
     .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.5.0"),
-    .package(
-      url: "https://github.com/awslabs/aws-sdk-swift.git",
-      branch: "aws-iot-device-sdk-swift-testing-branch"),
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -29,7 +26,6 @@ let package = Package(
       dependencies: [
         .product(name: "IotJobsClient", package: "aws-iot-device-sdk-swift"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "AWSIoT", package: "aws-sdk-swift"),
       ],
       path: "Sources")
   ]

--- a/Samples/ServiceClientSamples/JobsSample/README.md
+++ b/Samples/ServiceClientSamples/JobsSample/README.md
@@ -68,12 +68,12 @@ Your IoT Core Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerg
       "Effect": "Allow",
       "Action": "iot:Subscribe",
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/notify",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/notify-next",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/start-next/*",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*/update/*",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/get/*",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*/get/*"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/notify",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/notify-next",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/start-next/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/*/update/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/get/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/*/get/*"
       ]
     },
     {

--- a/Samples/ServiceClientSamples/JobsSample/README.md
+++ b/Samples/ServiceClientSamples/JobsSample/README.md
@@ -3,7 +3,7 @@
 [**Return to main sample list**](../../README.md)
 
 This is an interactive sample that supports a set of commands that allow you to interact with the AWS IoT [Jobs](https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html) Service.  The sample includes both control plane
-commands (that require the AWS SDK for Swift and use HTTP as transport) and data plane commands (that use the device SDK and use MQTT as transport).  In a real use case,
+commands (that use the [AWS CLI](https://aws.amazon.com/cli/) and use HTTP as transport) and data plane commands (that use the device SDK and use MQTT as transport).  In a real use case,
 control plane commands would be issued by applications under control of the customer, while the data plane operations would be issued by software running on the
 IoT device itself.
 
@@ -68,12 +68,12 @@ Your IoT Core Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerg
       "Effect": "Allow",
       "Action": "iot:Subscribe",
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/notify",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/notify-next",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/start-next/*",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/*/update/*",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/get/*",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/*/get/*"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/notify",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/notify-next",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/start-next/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*/update/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/get/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*/get/*"
       ]
     },
     {
@@ -94,14 +94,27 @@ Note that in a real application, you may want to avoid the use of wildcards in y
 
 </details>
 
-Additionally, the sample's control plane operations require that AWS credentials with appropriate permissions be sourceable by the default credentials provider chain
-of the Swift SDK.  At a minimum, the following permissions must be granted:
+Additionally, the sample's control plane operations (`create-job` and `delete-job`) are executed via the [AWS CLI](https://aws.amazon.com/cli/).  You must have the AWS CLI installed and configured with credentials that have the appropriate IAM permissions before running the sample.
+
+#### AWS CLI Setup
+
+1. **Install the AWS CLI** — follow the [official installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) for your platform.
+
+2. **Configure credentials** — run `aws configure` (or set the standard `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` environment variables).  The region configured in the CLI does not need to match the `<region>` argument passed to the sample; the sample always passes `--region <region>` explicitly to every CLI call.
+
+3. **Required IAM permissions** — the credentials used by the CLI must allow at least the following actions:
+
 <details>
 <summary>Sample Policy</summary>
 <pre>
 {
   "Version": "2012-10-17",
   "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iot:DescribeThing",
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:thing/<b>thingname</b>"
+    },
     {
       "Effect": "Allow",
       "Action": "iot:CreateJob",
@@ -128,7 +141,8 @@ Replace with the following with the data from your AWS account:
 * `<thingname>`: The name of your AWS IoT Core thing you want the device connection to be associated with
 
 Notice that you must provide `iot:CreateJob` permission to all things targeted by your jobs as well as the job itself.  In this example, we use a wildcard for the
-job permission so that you can name the jobs whatever you would like.
+job permission so that you can name the jobs whatever you would like.  The `iot:DescribeThing` permission is needed so the sample can look up the thing's ARN
+when creating a job.
 
 </details>
 
@@ -449,7 +463,7 @@ At this point, no incomplete job executions remain.
 
 ### Job Cleanup
 When all executions for a given job have reached a terminal state (SUCCEEDED, FAILED, CANCELED), you can delete the jobs themselves.  This is a control plane operation
-that requires the AWS SDK for Swift and should not be performed by the device executing jobs:
+executed via the AWS CLI and should not be performed by the device executing jobs:
 
 ```
 delete-job Job1

--- a/Samples/ServiceClientSamples/JobsSample/Sources/jobsSample.swift
+++ b/Samples/ServiceClientSamples/JobsSample/Sources/jobsSample.swift
@@ -1,13 +1,33 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-import AWSIoT
 // ArgumentParser is used by the sample to parse arguments.
 // This is not a required import for the MQTT5 Client.
 import ArgumentParser
 import AwsIotDeviceSdkSwift
 import Foundation
 import IotJobsClient
+
+// Free function that runs an AWS CLI command and returns trimmed stdout, or nil on failure.
+@discardableResult
+func awsCLI(_ arguments: [String]) -> String? {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+  process.arguments = ["aws"] + arguments
+  let pipe = Pipe()
+  process.standardOutput = pipe
+  process.standardError = Pipe()  // suppress stderr
+  do {
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else { return nil }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+  } catch {
+    print("AWS CLI error: \(error)")
+    return nil
+  }
+}
 
 @main
 struct ShadowClientSample: AsyncParsableCommand {
@@ -40,7 +60,7 @@ struct ShadowClientSample: AsyncParsableCommand {
       """
 
       Usage:
-      IoT control plane commands:
+      IoT control plane commands (executed via the AWS CLI):
           create-job <jobId> <job-document-as-json> -- create a new job with the specified job id and (JSON) document
           delete-job <jobId>                        -- deletes a job with the specified job id
 
@@ -124,40 +144,11 @@ struct ShadowClientSample: AsyncParsableCommand {
       return
     }
 
-    do {
-      // IoTClient is used for control plane operations
-      let iotClient = try await AWSIoT.IoTClient(
-        config: IoTClient.IoTClientConfiguration(region: region))
-
-      clientState.iotClient = iotClient
-    } catch {
-      print("Failed to setup IoTClient with error: \(error)")
-      return
-    }
-
-    do {
-      let describeThingInput = DescribeThingInput(thingName: thingName)
-      let describeThingOutput = try await clientState.iotClient!.describeThing(
-        input: describeThingInput)
-      guard let thingArn: String = describeThingOutput.thingArn else {
-        print("Failed to retrieve Arn for thingName: \(thingName)")
-        return
-      }
-      clientState.thingArn = thingArn
-    } catch {
-      print(
-        "Failed to retreive Arn for provided thingName: \(thingName) with error: \(error)"
-      )
-      return
-    }
-
     // Display commands.
     showMenu()
 
     // Enter the interactive loop.
-    await interactiveLoop(
-      jobsClient: clientState.jobsClient!, iotClient: clientState.iotClient!,
-      clientState: clientState)
+    await interactiveLoop(jobsClient: clientState.jobsClient!, clientState: clientState)
 
   }
 
@@ -317,7 +308,7 @@ struct ShadowClientSample: AsyncParsableCommand {
     }
   }
 
-  // Helper function that takes user input JSON and converts it to the [String: Any] type expected for `ShadowState`
+  // Helper function that parses a JSON string returned by the AWS CLI into a [String: Any] dictionary
   func parseJSONStringToDictionary(_ json: String) -> [String: Any]? {
     guard let data = json.data(using: .utf8) else {
       print("Failed to encode string to Data")
@@ -341,7 +332,7 @@ struct ShadowClientSample: AsyncParsableCommand {
 
   // Main loop that runs while the sample is active
   func interactiveLoop(
-    jobsClient: IotJobsClient, iotClient: AWSIoT.IoTClient, clientState: ClientState
+    jobsClient: IotJobsClient, clientState: ClientState
   ) async {
     var shouldExit = false
     while !shouldExit {
@@ -440,34 +431,62 @@ struct ShadowClientSample: AsyncParsableCommand {
               showMenu()
               break
             }
+            let jobId = String(tokens[1])
             let inputJSON = tokens.dropFirst(2).joined(separator: " ")
-            let createJobInput = CreateJobInput(
-              document: inputJSON,
-              jobId: String(tokens[1]),
-              targetSelection: IoTClientTypes.TargetSelection.snapshot,
-              targets: [clientState.thingArn!])
-            do {
-              let result = try await iotClient.createJob(input: createJobInput)
+
+            // Look up the thing ARN via the AWS CLI
+            guard
+              let thingArn = awsCLI([
+                "iot", "describe-thing",
+                "--thing-name", thingName,
+                "--query", "thingArn",
+                "--output", "text",
+                "--region", region,
+              ])
+            else {
+              print("Error: failed to retrieve ARN for thing '\(thingName)' via AWS CLI.")
+              break
+            }
+
+            // Create the job via the AWS CLI
+            guard
+              let createJobOutput = awsCLI([
+                "iot", "create-job",
+                "--job-id", jobId,
+                "--targets", thingArn,
+                "--document", inputJSON,
+                "--target-selection", "SNAPSHOT",
+                "--region", region,
+              ])
+            else {
+              print("Error: failed to create job '\(jobId)' via AWS CLI.")
+              break
+            }
+
+            // Parse and display the result
+            if let result = parseJSONStringToDictionary(createJobOutput) {
               print(
                 """
 
                 ─── CreateJobOutput ───────────────────────────────────────────────────────────────
-                description: \(result.description ?? "<nil>")
-                jobArn: \(result.jobArn ?? "<nil>")
-                jobId: \(result.jobId ?? "<nil>")
+                description: \(result["description"] as? String ?? "<nil>")
+                jobArn: \(result["jobArn"] as? String ?? "<nil>")
+                jobId: \(result["jobId"] as? String ?? "<nil>")
 
                 """)
-            } catch {
-              print("Error encountered while attempting to create job \(error)")
+            } else {
+              print(createJobOutput)
             }
 
           } else if lowercasedInput.hasPrefix("delete-job") {
-            print("Deleting Job with jobId: " + String(tokens[1]))
-            let deleteJobInput = DeleteJobInput(jobId: String(tokens[1]))
-            do {
-              let _ = try await iotClient.deleteJob(input: deleteJobInput)
-            } catch {
-              print("Error encountered while attempting to delete job \(error)")
+            let jobId = String(tokens[1])
+            print("Deleting Job with jobId: " + jobId)
+            if awsCLI([
+              "iot", "delete-job",
+              "--job-id", jobId,
+              "--region", region,
+            ]) == nil {
+              print("Error: failed to delete job '\(jobId)' via AWS CLI.")
             }
           } else {
             print("Invalid jobs command")
@@ -482,9 +501,7 @@ struct ShadowClientSample: AsyncParsableCommand {
 // Contains members that need to be accessed from across the sample and to prevent multiple resume calls
 final class ClientState {
   var mqttClient: Mqtt5Client?
-  var iotClient: IoTClient?
   var jobsClient: IotJobsClient?
-  var thingArn: String?
   var stream1: StreamingOperation?
   var stream2: StreamingOperation?
   private var isResumed = false


### PR DESCRIPTION
We do not want a dependency on aws-sdk-swift for the jobs sandbox sample.

Operations have been replaced with AWS CLI commands.

README updated to reflect new pre-requisites and instructions on use.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
