### PR TITLE
fix(ci): Prevent script injection in GHA workflows

### DIFF
--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -24,9 +24,12 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        REPO: ${{ github.repository }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        if [ "$IS_REGRESSION" == "true" ]; then
+          gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$REPO"
         else
-          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$REPO"
         fi

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -63,8 +63,10 @@ jobs:
 
       - name: Extract version from tag
         id: get_version
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_NAME="$RELEASE_TAG_NAME"
           # Remove the 'v' prefix to get the version
           VERSION=${TAG_NAME#v}
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -64,9 +64,8 @@ jobs:
       - name: Extract version from tag
         id: get_version
         env:
-          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          TAG_NAME="$RELEASE_TAG_NAME"
           # Remove the 'v' prefix to get the version
           VERSION=${TAG_NAME#v}
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move untrusted github.event.* interpolations out of run: blocks and into env: variables, then reference via "$VAR" inside the shell script. Eliminates script-injection sinks flagged by AppSec.

Affected workflows:
  - update-version.yml (release.tag_name)
  - issue-regression-labeler.yml (issue.number, repository, steps.check_regression.outputs.is_regression)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
