### PR TITLE
Fix setting flow control option

### DIFF
--- a/Sources/AwsIotDeviceSdkSwift/Mqtt5ClientBuilder.swift
+++ b/Sources/AwsIotDeviceSdkSwift/Mqtt5ClientBuilder.swift
@@ -823,8 +823,6 @@ public class Mqtt5ClientBuilder {
     // Builds _username with one set by user, custom auth, and metrics
     buildUsername()
 
-    _extendedValidationAndFlowControlOptions = .awsIotCoreDefaults
-
     // Configure connection options
     let connectOptions = MqttConnectOptions(
       keepAliveInterval: _keepAliveInterval,


### PR DESCRIPTION
Do not override a flow control options in `Mqtt5ClientBuilder::build` since at this point it's either already set to the default value or changed with the `withExtendedValidationAndFlowControlOptions` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
