### PR TITLE
Set x-amzn-mqtt-ca ALPN for direct mTLS connections

### DIFF
--- a/Sources/AwsIotDeviceSdkSwift/Mqtt5ClientBuilder.swift
+++ b/Sources/AwsIotDeviceSdkSwift/Mqtt5ClientBuilder.swift
@@ -83,6 +83,11 @@ public class Mqtt5ClientBuilder {
       certificatePath: certPath, privateKeyPath: keyPath)
     _endpoint = endpoint
     _port = 8883
+    // On platforms that support ALPN, use the "x-amzn-mqtt-ca" protocol so IoT Core accepts the
+    // direct mTLS connection on either port.
+    if TLSContextOptions.isAlpnSupported() {
+      _tlsOptions?.setAlpnList(["x-amzn-mqtt-ca"])
+    }
     // Track certificate source for metrics
     _featureList.certificateSource = .certificateFiles
   }
@@ -93,6 +98,11 @@ public class Mqtt5ClientBuilder {
       certificateData: certData, privateKeyData: keyData)
     _endpoint = endpoint
     _port = 8883
+    // On platforms that support ALPN, use the "x-amzn-mqtt-ca" protocol so IoT Core accepts the
+    // direct mTLS connection on either port.
+    if TLSContextOptions.isAlpnSupported() {
+      _tlsOptions?.setAlpnList(["x-amzn-mqtt-ca"])
+    }
     // Track certificate source for metrics (certificate data is treated as certificate files)
     _featureList.certificateSource = .certificateFiles
   }
@@ -103,6 +113,11 @@ public class Mqtt5ClientBuilder {
       pkcs12Path: pkcs12Path, password: pkcs12Password)
     _endpoint = endpoint
     _port = 8883
+    // On platforms that support ALPN, use the "x-amzn-mqtt-ca" protocol so IoT Core accepts the
+    // direct mTLS connection on either port.
+    if TLSContextOptions.isAlpnSupported() {
+      _tlsOptions?.setAlpnList(["x-amzn-mqtt-ca"])
+    }
     // Track certificate source for metrics
     _featureList.certificateSource = .pkcs12File
   }

--- a/Sources/AwsIotDeviceSdkSwift/Mqtt5ClientBuilder.swift
+++ b/Sources/AwsIotDeviceSdkSwift/Mqtt5ClientBuilder.swift
@@ -28,6 +28,7 @@ public class Mqtt5ClientBuilder {
 
   private var _endpoint: String?
   private var _port: UInt32 = 8883
+  private var _isDirectMtls: Bool = false
   private var _onWebsocketTransform: OnWebSocketHandshakeIntercept?
   private var _clientId: String?
   private var _username: String?
@@ -83,11 +84,7 @@ public class Mqtt5ClientBuilder {
       certificatePath: certPath, privateKeyPath: keyPath)
     _endpoint = endpoint
     _port = 8883
-    // On platforms that support ALPN, use the "x-amzn-mqtt-ca" protocol so IoT Core accepts the
-    // direct mTLS connection on either port.
-    if TLSContextOptions.isAlpnSupported() {
-      _tlsOptions?.setAlpnList(["x-amzn-mqtt-ca"])
-    }
+    _isDirectMtls = true
     // Track certificate source for metrics
     _featureList.certificateSource = .certificateFiles
   }
@@ -98,11 +95,7 @@ public class Mqtt5ClientBuilder {
       certificateData: certData, privateKeyData: keyData)
     _endpoint = endpoint
     _port = 8883
-    // On platforms that support ALPN, use the "x-amzn-mqtt-ca" protocol so IoT Core accepts the
-    // direct mTLS connection on either port.
-    if TLSContextOptions.isAlpnSupported() {
-      _tlsOptions?.setAlpnList(["x-amzn-mqtt-ca"])
-    }
+    _isDirectMtls = true
     // Track certificate source for metrics (certificate data is treated as certificate files)
     _featureList.certificateSource = .certificateFiles
   }
@@ -113,11 +106,7 @@ public class Mqtt5ClientBuilder {
       pkcs12Path: pkcs12Path, password: pkcs12Password)
     _endpoint = endpoint
     _port = 8883
-    // On platforms that support ALPN, use the "x-amzn-mqtt-ca" protocol so IoT Core accepts the
-    // direct mTLS connection on either port.
-    if TLSContextOptions.isAlpnSupported() {
-      _tlsOptions?.setAlpnList(["x-amzn-mqtt-ca"])
-    }
+    _isDirectMtls = true
     // Track certificate source for metrics
     _featureList.certificateSource = .pkcs12File
   }
@@ -871,6 +860,12 @@ public class Mqtt5ClientBuilder {
         // Apply labels if available
         if _certLabel != nil || _keyLabel != nil {
           try tlsOptions.setSecitemLabels(certLabel: _certLabel, keyLabel: _keyLabel)
+        }
+
+        // For direct mTLS connections on platforms that support ALPN, use the "x-amzn-mqtt-ca"
+        // protocol so IoT Core accepts the connection on either port.
+        if _isDirectMtls && TLSContextOptions.isAlpnSupported() {
+          tlsOptions.setAlpnList(["x-amzn-mqtt-ca"])
         }
 
         _tlsCtx = try TLSContext(options: tlsOptions, mode: .client)

--- a/Tests/AwsIotDeviceSdkSwiftTests/AwsIotDeviceSdkSwiftTests.swift
+++ b/Tests/AwsIotDeviceSdkSwiftTests/AwsIotDeviceSdkSwiftTests.swift
@@ -227,6 +227,51 @@ class Mqtt5ClientTests: XCBaseTestCase {
     try disconnectClientCleanup(client: mqttClient, testContext: context)
   }
 
+  /// A direct mTLS connection on port 443 requires the "x-amzn-mqtt-ca" ALPN protocol to be set so
+  /// IoT Core accepts mTLS over the HTTPS port. This connection fails if that ALPN is not applied.
+  func testMqttBuilderMTLSFromPathPort443() throws {
+
+    let certPath, keyPath, endpoint: String
+
+    if (!isIOSDeviceFarm) {
+      try skipIfPlatformDoesntSupportTLS()
+      certPath = try getEnvironmentVarOrSkipTest(
+        environmentVarName: "AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
+      keyPath = try getEnvironmentVarOrSkipTest(
+        environmentVarName: "AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
+      endpoint = try getEnvironmentVarOrSkipTest(
+        environmentVarName: "AWS_TEST_MQTT5_IOT_CORE_HOST")
+    } else {
+      guard let certURL = Bundle.main.url(forResource: "cert", withExtension: "pem"),
+        let keyURL = Bundle.main.url(forResource: "privatekey", withExtension: "pem")
+      else {
+        XCTFail("Missing cert or key resource.")
+        throw MqttTestError.resourceMissing
+      }
+
+      certPath = certURL.relativePath
+      keyPath = keyURL.relativePath
+      endpoint = "<AWS_TEST_MQTT5_IOT_CORE_HOST>"
+    }
+    let context = MqttTestContext(contextName: "MTLSFromPathPort443")
+    let builder = try Mqtt5ClientBuilder.mtlsFromPath(
+      endpoint: endpoint, certPath: certPath, keyPath: keyPath)
+
+    builder.withPort(443)
+    builder.withCallbacks(
+      onPublishReceived: context.onPublishReceived,
+      onLifecycleEventConnectionSuccess: context.onLifecycleEventConnectionSuccess,
+      onLifecycleEventConnectionFailure: context.onLifecycleEventConnectionFailure,
+      onLifecycleEventDisconnection: context.onLifecycleEventDisconnection,
+      onLifecycleEventStopped: context.onLifecycleEventStopped)
+
+    let mqttClient = try builder.build()
+
+    XCTAssertNotNil(mqttClient)
+    try connectClient(client: mqttClient, testContext: context)
+    try disconnectClientCleanup(client: mqttClient, testContext: context)
+  }
+
   func testMqttBuilderMTLSFromData() throws {
 
     let certFileURL, keyFileURL: URL


### PR DESCRIPTION
Sets the `x-amzn-mqtt-ca` ALPN protocol on the three direct mTLS builder factories (`mtlsFromPath`, `mtlsFromData`, `mtlsFromPKCS12`) when the platform supports ALPN. The default port is unchanged, stays 8883.

Without this ALPN, an mTLS connection cannot be established over port 443: IoT Core requires the `x-amzn-mqtt-ca` ALPN to accept mTLS on the HTTPS port. This change brings Swift in line with the other SDKs and enables mTLS-on-443 for users who set withPort(443).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
